### PR TITLE
Add shelves and improved profile UI

### DIFF
--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -3,9 +3,8 @@ const prisma = require('../prisma');
 const authenticateToken = require('../middleware/authMiddleware');
 const router = express.Router();
 const { serializeUser } = require('../utils/serializer');
-// POST /api/user/books - Add book to logged-in user's library
-router.post('/user/books', authenticateToken, async (req, res) => {
-  const userId = req.user.id;
+
+async function findOrCreateBook(data) {
   const {
     googleBooksId,
     title,
@@ -22,66 +21,59 @@ router.post('/user/books', authenticateToken, async (req, res) => {
     isbn10,
     isbn13,
     authors,
-    categories
-  } = req.body;
+    categories,
+  } = data;
 
-  try {
-    // Check if book exists
-    let book = await prisma.book.findUnique({
-      where: { googleBooksId }
+  let book = await prisma.book.findUnique({ where: { googleBooksId } });
+  if (!book) {
+    book = await prisma.book.create({
+      data: {
+        googleBooksId,
+        title,
+        subtitle,
+        description,
+        publishedDate: publishedDate ? new Date(publishedDate) : null,
+        pageCount,
+        language,
+        thumbnailUrl,
+        previewLink,
+        infoLink,
+        averageRating,
+        ratingsCount,
+        isbn10,
+        isbn13,
+      },
     });
 
-    // Create book if not exists
-    if (!book) {
-      book = await prisma.book.create({
-        data: {
-          googleBooksId,
-          title,
-          subtitle,
-          description,
-          publishedDate: publishedDate ? new Date(publishedDate) : null,
-          pageCount,
-          language,
-          thumbnailUrl,
-          previewLink,
-          infoLink,
-          averageRating,
-          ratingsCount,
-          isbn10,
-          isbn13
-        }
+    for (const name of authors || []) {
+      const author = await prisma.author.upsert({
+        where: { name },
+        update: {},
+        create: { name },
       });
-
-      // Link authors
-      for (const name of authors || []) {
-        const author = await prisma.author.upsert({
-          where: { name },
-          update: {},
-          create: { name }
-        });
-        await prisma.bookAuthor.create({
-          data: {
-            bookId: book.id,
-            authorId: author.id
-          }
-        });
-      }
-
-      // Link categories
-      for (const name of categories || []) {
-        const category = await prisma.category.upsert({
-          where: { name },
-          update: {},
-          create: { name }
-        });
-        await prisma.bookCategory.create({
-          data: {
-            bookId: book.id,
-            categoryId: category.id
-          }
-        });
-      }
+      await prisma.bookAuthor.create({
+        data: { bookId: book.id, authorId: author.id },
+      });
     }
+
+    for (const name of categories || []) {
+      const category = await prisma.category.upsert({
+        where: { name },
+        update: {},
+        create: { name },
+      });
+      await prisma.bookCategory.create({
+        data: { bookId: book.id, categoryId: category.id },
+      });
+    }
+  }
+  return book;
+}
+// POST /api/user/books - Add book to logged-in user's library
+router.post('/user/books', authenticateToken, async (req, res) => {
+  const userId = req.user.id;
+  try {
+    const book = await findOrCreateBook(req.body);
 
     // Link book to user
     await prisma.userBook.upsert({
@@ -160,6 +152,88 @@ router.get('/me', authenticateToken, async (req, res) => {
   } catch (error) {
     console.error(error);
     res.status(500).json({ error: 'Something went wrong' });
+  }
+});
+
+// Create a new shelf
+router.post('/user/shelves', authenticateToken, async (req, res) => {
+  const userId = req.user.id;
+  const { name } = req.body;
+  if (!name) return res.status(400).json({ error: 'Name is required' });
+  try {
+    const shelf = await prisma.shelf.create({ data: { name, userId } });
+    res.status(201).json(shelf);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to create shelf' });
+  }
+});
+
+// Get shelves with books
+router.get('/user/shelves', authenticateToken, async (req, res) => {
+  const userId = req.user.id;
+  try {
+    const shelves = await prisma.shelf.findMany({
+      where: { userId },
+      include: {
+        shelfBooks: {
+          include: {
+            book: {
+              include: {
+                authors: { include: { author: true } },
+                categories: { include: { category: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+    const result = shelves.map(s => ({
+      id: s.id,
+      name: s.name,
+      books: s.shelfBooks.map(sb => ({
+        id: sb.book.googleBooksId || String(sb.book.id),
+        volumeInfo: {
+          title: sb.book.title,
+          subtitle: sb.book.subtitle,
+          description: sb.book.description,
+          publishedDate: sb.book.publishedDate?.toISOString(),
+          pageCount: sb.book.pageCount,
+          language: sb.book.language,
+          authors: sb.book.authors.map(a => a.author.name),
+          categories: sb.book.categories.map(c => c.category.name),
+          imageLinks: { thumbnail: sb.book.thumbnailUrl },
+          infoLink: sb.book.infoLink,
+        },
+      }))
+    }));
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch shelves' });
+  }
+});
+
+// Add book to shelf
+router.post('/user/shelves/:id/books', authenticateToken, async (req, res) => {
+  const userId = req.user.id;
+  const shelfId = parseInt(req.params.id, 10);
+  try {
+    const shelf = await prisma.shelf.findFirst({ where: { id: shelfId, userId } });
+    if (!shelf) return res.status(404).json({ error: 'Shelf not found' });
+
+    const book = await findOrCreateBook(req.body);
+
+    await prisma.shelfBook.upsert({
+      where: { shelfId_bookId: { shelfId, bookId: book.id } },
+      update: {},
+      create: { shelfId, bookId: book.id },
+    });
+
+    res.status(201).json({ message: 'Book added to shelf' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to add book to shelf' });
   }
 });
 

--- a/prisma/migrations/20250610122258_add_shelf/migration.sql
+++ b/prisma/migrations/20250610122258_add_shelf/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "Shelf" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Shelf_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ShelfBook" (
+    "shelfId" INTEGER NOT NULL,
+    "bookId" INTEGER NOT NULL,
+    "addedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ShelfBook_pkey" PRIMARY KEY ("shelfId","bookId")
+);
+
+-- AddForeignKey
+ALTER TABLE "Shelf" ADD CONSTRAINT "Shelf_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ShelfBook" ADD CONSTRAINT "ShelfBook_shelfId_fkey" FOREIGN KEY ("shelfId") REFERENCES "Shelf"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ShelfBook" ADD CONSTRAINT "ShelfBook_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,7 @@ model User {
   passwordHash String
   createdAt    DateTime @default(now())
   userBooks    UserBook[]
+  shelves      Shelf[]
 }
 
 model Book {
@@ -76,4 +77,23 @@ model UserBook {
   addedAt  DateTime @default(now())
 
   @@id([userId, bookId])
+}
+
+model Shelf {
+  id        Int        @id @default(autoincrement())
+  name      String
+  user      User       @relation(fields: [userId], references: [id])
+  userId    Int
+  shelfBooks ShelfBook[]
+  createdAt DateTime   @default(now())
+}
+
+model ShelfBook {
+  shelf     Shelf @relation(fields: [shelfId], references: [id])
+  shelfId   Int
+  book      Book  @relation(fields: [bookId], references: [id])
+  bookId    Int
+  addedAt   DateTime @default(now())
+
+  @@id([shelfId, bookId])
 }

--- a/src/app/pages/profile/profile.component.css
+++ b/src/app/pages/profile/profile.component.css
@@ -22,6 +22,34 @@
   margin-bottom: 1rem;
 }
 
+.create-shelf {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.book-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.shelf-select {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.shelf-list {
+  margin-top: 2rem;
+}
+
+.shelf-books {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
 .logout-btn {
   margin-top: 1rem;
 }

--- a/src/app/pages/profile/profile.component.html
+++ b/src/app/pages/profile/profile.component.html
@@ -11,10 +11,33 @@
 
   <div class="playlists">
     <button class="playlist-btn">Added Books</button>
+    <div class="create-shelf">
+      <input type="text" [(ngModel)]="newShelfName" placeholder="New shelf name" />
+      <button (click)="createShelf()">Create Shelf</button>
+    </div>
   </div>
 
   <div class="books-grid">
-    <app-book-card *ngFor="let b of filteredBooks()" [book]="b"></app-book-card>
+    <div class="book-wrapper" *ngFor="let b of filteredBooks()">
+      <app-book-card [book]="b"></app-book-card>
+      <div class="shelf-select" *ngIf="shelves.length">
+        <select [(ngModel)]="selectedShelf[b.id]">
+          <option [ngValue]="null">Select shelf</option>
+          <option *ngFor="let s of shelves" [ngValue]="s.id">{{ s.name }}</option>
+        </select>
+        <button (click)="addBookToShelf(b, selectedShelf[b.id])">Add</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="shelf-list" *ngIf="shelves.length">
+    <h3>Your Shelves</h3>
+    <div *ngFor="let s of shelves" class="shelf">
+      <h4>{{ s.name }}</h4>
+      <div class="shelf-books">
+        <app-book-card *ngFor="let sb of s.books" [book]="sb"></app-book-card>
+      </div>
+    </div>
   </div>
 
   <button (click)="logout()" class="logout-btn">Logout</button>

--- a/src/app/services/shelf.service.ts
+++ b/src/app/services/shelf.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class ShelfService {
+  private api = 'http://localhost:3000/api/user/shelves';
+
+  constructor(private http: HttpClient) {}
+
+  getShelves(): Observable<any[]> {
+    return this.http.get<any[]>(this.api);
+  }
+
+  createShelf(name: string): Observable<any> {
+    return this.http.post(this.api, { name });
+  }
+
+  addBookToShelf(shelfId: number, payload: any): Observable<any> {
+    return this.http.post(`${this.api}/${shelfId}/books`, payload);
+  }
+}

--- a/src/app/shared/components/navbar/navbar.component.css
+++ b/src/app/shared/components/navbar/navbar.component.css
@@ -119,6 +119,14 @@
   gap: 8px;
 }
 
+.profile-link {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: inherit;
+  text-decoration: none;
+}
+
 .avatar {
   width: 32px;
   height: 32px;

--- a/src/app/shared/components/navbar/navbar.component.html
+++ b/src/app/shared/components/navbar/navbar.component.html
@@ -21,12 +21,14 @@
       </div>
       
       <div *ngIf="username" class="user-info">
-        <img
-          [src]="'https://api.dicebear.com/6.x/initials/svg?seed=' + username"
-          alt="Avatar"
-          class="avatar"
-        />
-        <span class="username">{{ username }}</span>
+        <a routerLink="/profile" class="profile-link">
+          <img
+            [src]="'https://api.dicebear.com/6.x/initials/svg?seed=' + username"
+            alt="Avatar"
+            class="avatar"
+          />
+          <span class="username">{{ username }}</span>
+        </a>
         <button (click)="logout()" class="login-btn">Wyloguj</button>
       </div>
       


### PR DESCRIPTION
## Summary
- add Shelf & ShelfBook models with migration
- allow creating and managing shelves via new backend routes
- expose a ShelfService for frontend access
- enhance profile component with shelf management UI
- make navbar avatar link to profile

## Testing
- `npm ci`
- `npm test` *(fails: No inputs were found)*

------
https://chatgpt.com/codex/tasks/task_e_68482307456c8328833a3dac852c4435