### PR TITLE
Add basic library page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { CatalogComponent } from './pages/catalog/catalog.component';
 import { LoginComponent } from './pages/login/login.component';
 import { RegisterComponent } from './pages/register/register.component';
 import { ProfileComponent } from './pages/profile/profile.component';
+import { LibraryComponent } from './pages/library/library.component';
 import { AuthGuard } from './services/auth.guard';
 import { AboutUsComponent } from './pages/about-us/about-us.component';
 import { BestsellersComponent } from './pages/bestsellers/bestsellers.component';
@@ -16,6 +17,7 @@ export const routes: Routes = [
   { path: 'catalogue', component: CatalogComponent },
   { path: 'login', component: LoginComponent },
   { path: 'register', component: RegisterComponent },
+  { path: 'library', component: LibraryComponent, canActivate: [AuthGuard] },
   { path: 'profile', component: ProfileComponent, canActivate: [AuthGuard] },
   { path: 'bestsellers', component: BestsellersComponent },
   { path: 'about-us', component: AboutUsComponent },

--- a/src/app/pages/library/library.component.css
+++ b/src/app/pages/library/library.component.css
@@ -1,0 +1,55 @@
+.library-page {
+  padding: 2rem;
+  color: #fff;
+}
+
+.filters {
+  margin-bottom: 1rem;
+}
+
+.filters input,
+.filters select {
+  margin-right: 0.5rem;
+}
+
+.books-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
+.playlists {
+  margin-bottom: 1rem;
+}
+
+.create-shelf {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.book-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.shelf-select {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.shelf-list {
+  margin-top: 2rem;
+}
+
+.shelf-books {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
+.logout-btn {
+  margin-top: 1rem;
+}

--- a/src/app/pages/library/library.component.html
+++ b/src/app/pages/library/library.component.html
@@ -1,0 +1,44 @@
+<div class="library-page" *ngIf="username">
+  <h2>{{ username }}'s Library</h2>
+
+  <div class="filters">
+    <input type="text" [(ngModel)]="searchTerm" placeholder="Search books" />
+    <select [(ngModel)]="selectedCategory">
+      <option value="">All Categories</option>
+      <option *ngFor="let cat of categories" [value]="cat">{{ cat }}</option>
+    </select>
+  </div>
+
+  <div class="playlists">
+    <button class="playlist-btn">Added Books</button>
+    <div class="create-shelf">
+      <input type="text" [(ngModel)]="newShelfName" placeholder="New shelf name" />
+      <button (click)="createShelf()">Create Shelf</button>
+    </div>
+  </div>
+
+  <div class="books-grid">
+    <div class="book-wrapper" *ngFor="let b of filteredBooks()">
+      <app-book-card [book]="b"></app-book-card>
+      <div class="shelf-select" *ngIf="shelves.length">
+        <select [(ngModel)]="selectedShelf[b.id]">
+          <option [ngValue]="null">Select shelf</option>
+          <option *ngFor="let s of shelves" [ngValue]="s.id">{{ s.name }}</option>
+        </select>
+        <button (click)="addBookToShelf(b, selectedShelf[b.id])">Add</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="shelf-list" *ngIf="shelves.length">
+    <h3>Your Shelves</h3>
+    <div *ngFor="let s of shelves" class="shelf">
+      <h4>{{ s.name }}</h4>
+      <div class="shelf-books">
+        <app-book-card *ngFor="let sb of s.books" [book]="sb"></app-book-card>
+      </div>
+    </div>
+  </div>
+
+  <button (click)="logout()" class="logout-btn">Logout</button>
+</div>

--- a/src/app/pages/library/library.component.ts
+++ b/src/app/pages/library/library.component.ts
@@ -1,0 +1,113 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { Router, RouterModule } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
+import { AuthService } from '../../services/auth.service';
+import { LibraryService } from '../../services/library.service';
+import { ShelfService } from '../../services/shelf.service';
+import { BookCardComponent } from '../../shared/components/book-card/book-card.component';
+import { Book } from '../../shared/components/book';
+
+
+@Component({
+  standalone: true,
+  selector: 'app-library',
+  imports: [CommonModule, RouterModule, FormsModule, HttpClientModule, BookCardComponent],
+  templateUrl: './library.component.html',
+  styleUrls: ['./library.component.css']
+})
+export class LibraryComponent implements OnInit {
+  username: string | null = null;
+  books: Book[] = [];
+  categories: string[] = [];
+  selectedCategory = '';
+  searchTerm = '';
+  shelves: any[] = [];
+  newShelfName = '';
+  selectedShelf: { [key: string]: number } = {};
+
+  constructor(
+    private auth: AuthService,
+    private router: Router,
+    private library: LibraryService,
+    private shelvesService: ShelfService
+  ) {}
+
+  ngOnInit(): void {
+    if (!this.auth.isLoggedIn()) {
+      this.router.navigate(['/login']);
+      return;
+    }
+    this.username = this.auth.getUsername();
+    this.loadBooks();
+    this.loadShelves();
+  }
+
+  loadBooks(): void {
+    this.library.getMyBooks().subscribe({
+      next: books => {
+        this.books = books;
+        this.categories = Array.from(new Set(books.flatMap(b => b.volumeInfo.categories || [])));
+      },
+      error: err => console.error('Failed to load books', err)
+    });
+  }
+
+  loadShelves(): void {
+    this.shelvesService.getShelves().subscribe({
+      next: s => (this.shelves = s),
+      error: err => console.error('Failed to load shelves', err),
+    });
+  }
+
+  createShelf(): void {
+    if (!this.newShelfName.trim()) return;
+    this.shelvesService.createShelf(this.newShelfName).subscribe({
+      next: shelf => {
+        this.shelves.push(shelf);
+        this.newShelfName = '';
+      },
+      error: err => console.error('Failed to create shelf', err),
+    });
+  }
+
+  addBookToShelf(book: Book, shelfId: number): void {
+    if (!shelfId) return;
+    const payload = {
+      googleBooksId: book.id,
+      title: book.volumeInfo.title,
+      subtitle: book.volumeInfo.subtitle,
+      description: book.volumeInfo.description,
+      publishedDate: book.volumeInfo.publishedDate,
+      pageCount: book.volumeInfo.pageCount,
+      language: book.volumeInfo.language,
+      thumbnailUrl: book.volumeInfo.imageLinks?.thumbnail,
+      previewLink: '',
+      infoLink: book.volumeInfo.infoLink,
+      averageRating: book.volumeInfo.averageRating,
+      ratingsCount: book.volumeInfo.ratingsCount,
+      isbn10: '',
+      isbn13: '',
+      authors: book.volumeInfo.authors,
+      categories: book.volumeInfo.categories,
+    };
+    this.shelvesService.addBookToShelf(shelfId, payload).subscribe({
+      next: () => this.loadShelves(),
+      error: err => console.error('Failed to add book to shelf', err),
+    });
+  }
+
+  filteredBooks(): Book[] {
+    return this.books.filter(b => {
+      const matchesCategory = this.selectedCategory ? (b.volumeInfo.categories || []).includes(this.selectedCategory) : true;
+      const matchesSearch = b.volumeInfo.title.toLowerCase().includes(this.searchTerm.toLowerCase());
+      return matchesCategory && matchesSearch;
+    });
+  }
+
+  logout(): void {
+    this.auth.logout();
+    this.router.navigate(['/login']);
+  }
+}

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -28,7 +28,7 @@ export class LoginComponent {
     };
 
     this.authService.login(this.email, this.password).subscribe({
-      next: () => this.router.navigate(['/profile']),
+      next: () => this.router.navigate(['/library']),
       error: (err: { error: { message: any; }; }) => this.errorMsg = err.error.message
     });
     

--- a/src/app/pages/profile/profile.component.css
+++ b/src/app/pages/profile/profile.component.css
@@ -3,53 +3,6 @@
   color: #fff;
 }
 
-.filters {
-  margin-bottom: 1rem;
-}
-
-.filters input,
-.filters select {
-  margin-right: 0.5rem;
-}
-
-.books-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-  gap: 1rem;
-}
-
-.playlists {
-  margin-bottom: 1rem;
-}
-
-.create-shelf {
-  margin-top: 0.5rem;
-  display: flex;
-  gap: 0.5rem;
-}
-
-.book-wrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.shelf-select {
-  margin-top: 0.5rem;
-  display: flex;
-  gap: 0.5rem;
-}
-
-.shelf-list {
-  margin-top: 2rem;
-}
-
-.shelf-books {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-  gap: 1rem;
-}
-
 .logout-btn {
   margin-top: 1rem;
 }

--- a/src/app/pages/profile/profile.component.html
+++ b/src/app/pages/profile/profile.component.html
@@ -1,44 +1,5 @@
 <div class="profile-page" *ngIf="username">
-  <h2>{{ username }}'s Library</h2>
-
-  <div class="filters">
-    <input type="text" [(ngModel)]="searchTerm" placeholder="Search books" />
-    <select [(ngModel)]="selectedCategory">
-      <option value="">All Categories</option>
-      <option *ngFor="let cat of categories" [value]="cat">{{ cat }}</option>
-    </select>
-  </div>
-
-  <div class="playlists">
-    <button class="playlist-btn">Added Books</button>
-    <div class="create-shelf">
-      <input type="text" [(ngModel)]="newShelfName" placeholder="New shelf name" />
-      <button (click)="createShelf()">Create Shelf</button>
-    </div>
-  </div>
-
-  <div class="books-grid">
-    <div class="book-wrapper" *ngFor="let b of filteredBooks()">
-      <app-book-card [book]="b"></app-book-card>
-      <div class="shelf-select" *ngIf="shelves.length">
-        <select [(ngModel)]="selectedShelf[b.id]">
-          <option [ngValue]="null">Select shelf</option>
-          <option *ngFor="let s of shelves" [ngValue]="s.id">{{ s.name }}</option>
-        </select>
-        <button (click)="addBookToShelf(b, selectedShelf[b.id])">Add</button>
-      </div>
-    </div>
-  </div>
-
-  <div class="shelf-list" *ngIf="shelves.length">
-    <h3>Your Shelves</h3>
-    <div *ngFor="let s of shelves" class="shelf">
-      <h4>{{ s.name }}</h4>
-      <div class="shelf-books">
-        <app-book-card *ngFor="let sb of s.books" [book]="sb"></app-book-card>
-      </div>
-    </div>
-  </div>
-
+  <h2>{{ username }}'s Profile</h2>
+  <p>Account details coming soon...</p>
   <button (click)="logout()" class="logout-btn">Logout</button>
 </div>

--- a/src/app/pages/profile/profile.component.ts
+++ b/src/app/pages/profile/profile.component.ts
@@ -1,38 +1,20 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
-import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { AuthService } from '../../services/auth.service';
-import { LibraryService } from '../../services/library.service';
-import { ShelfService } from '../../services/shelf.service';
-import { BookCardComponent } from '../../shared/components/book-card/book-card.component';
-import { Book } from '../../shared/components/book';
-
 
 @Component({
   standalone: true,
   selector: 'app-profile',
-  imports: [CommonModule, RouterModule, FormsModule, HttpClientModule, BookCardComponent],
+  imports: [CommonModule, RouterModule, HttpClientModule],
   templateUrl: './profile.component.html',
   styleUrls: ['./profile.component.css']
 })
 export class ProfileComponent implements OnInit {
   username: string | null = null;
-  books: Book[] = [];
-  categories: string[] = [];
-  selectedCategory = '';
-  searchTerm = '';
-  shelves: any[] = [];
-  newShelfName = '';
-  selectedShelf: { [key: string]: number } = {};
 
-  constructor(
-    private auth: AuthService,
-    private router: Router,
-    private library: LibraryService,
-    private shelvesService: ShelfService
-  ) {}
+  constructor(private auth: AuthService, private router: Router) {}
 
   ngOnInit(): void {
     if (!this.auth.isLoggedIn()) {
@@ -40,70 +22,6 @@ export class ProfileComponent implements OnInit {
       return;
     }
     this.username = this.auth.getUsername();
-    this.loadBooks();
-    this.loadShelves();
-  }
-
-  loadBooks(): void {
-    this.library.getMyBooks().subscribe({
-      next: books => {
-        this.books = books;
-        this.categories = Array.from(new Set(books.flatMap(b => b.volumeInfo.categories || [])));
-      },
-      error: err => console.error('Failed to load books', err)
-    });
-  }
-
-  loadShelves(): void {
-    this.shelvesService.getShelves().subscribe({
-      next: s => (this.shelves = s),
-      error: err => console.error('Failed to load shelves', err),
-    });
-  }
-
-  createShelf(): void {
-    if (!this.newShelfName.trim()) return;
-    this.shelvesService.createShelf(this.newShelfName).subscribe({
-      next: shelf => {
-        this.shelves.push(shelf);
-        this.newShelfName = '';
-      },
-      error: err => console.error('Failed to create shelf', err),
-    });
-  }
-
-  addBookToShelf(book: Book, shelfId: number): void {
-    if (!shelfId) return;
-    const payload = {
-      googleBooksId: book.id,
-      title: book.volumeInfo.title,
-      subtitle: book.volumeInfo.subtitle,
-      description: book.volumeInfo.description,
-      publishedDate: book.volumeInfo.publishedDate,
-      pageCount: book.volumeInfo.pageCount,
-      language: book.volumeInfo.language,
-      thumbnailUrl: book.volumeInfo.imageLinks?.thumbnail,
-      previewLink: '',
-      infoLink: book.volumeInfo.infoLink,
-      averageRating: book.volumeInfo.averageRating,
-      ratingsCount: book.volumeInfo.ratingsCount,
-      isbn10: '',
-      isbn13: '',
-      authors: book.volumeInfo.authors,
-      categories: book.volumeInfo.categories,
-    };
-    this.shelvesService.addBookToShelf(shelfId, payload).subscribe({
-      next: () => this.loadShelves(),
-      error: err => console.error('Failed to add book to shelf', err),
-    });
-  }
-
-  filteredBooks(): Book[] {
-    return this.books.filter(b => {
-      const matchesCategory = this.selectedCategory ? (b.volumeInfo.categories || []).includes(this.selectedCategory) : true;
-      const matchesSearch = b.volumeInfo.title.toLowerCase().includes(this.searchTerm.toLowerCase());
-      return matchesCategory && matchesSearch;
-    });
   }
 
   logout(): void {

--- a/src/app/shared/components/navbar/navbar.component.html
+++ b/src/app/shared/components/navbar/navbar.component.html
@@ -10,6 +10,7 @@
         <li><a routerLink="/catalogue" routerLinkActive="active">Catalogue</a></li>
         <li><a routerLink="/about-us" routerLinkActive="active">About us</a></li>
         <li><a routerLink="/contact" routerLinkActive="active">Contact</a></li>
+        <li *ngIf="username"><a routerLink="/library" routerLinkActive="active">Library</a></li>
 
 
       </ul>


### PR DESCRIPTION
## Summary
- add Library component as standalone page
- route to `/library` for authenticated users
- simplify Profile page and keep logout only
- redirect login to `/library`
- show Library menu item when logged in

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483c92a0f08328bcc0fa5f03834b48