### PR TITLE
Improve catalogue search

### DIFF
--- a/backend/routes/books.js
+++ b/backend/routes/books.js
@@ -125,6 +125,19 @@ router.get('/:googleBooksId/reviews', async (req, res) => {
   }
 });
 
+// Get list of categories from the database
+router.get('/categories', async (req, res) => {
+  try {
+    const categories = await prisma.category.findMany({
+      orderBy: { name: 'asc' }
+    });
+    res.json(categories.map(c => c.name));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch categories' });
+  }
+});
+
 // Add review for a book
 router.post('/:googleBooksId/reviews', authenticateToken, async (req, res) => {
   const { googleBooksId } = req.params;

--- a/src/app/pages/catalog/catalog.component.html
+++ b/src/app/pages/catalog/catalog.component.html
@@ -4,16 +4,32 @@
   <!-- Search Controls -->
   <div class="search-controls">
     <input
-      [(ngModel)]="searchTerm"
+      [(ngModel)]="searchTitle"
       type="text"
-      placeholder="Szukaj książki..."
+      placeholder="Title"
       class="search-input"
     />
-    <button (click)="searchBooks()" class="search-button">Szukaj</button>
+    <input
+      [(ngModel)]="searchAuthor"
+      type="text"
+      placeholder="Author"
+      class="search-input"
+    />
+    <select [(ngModel)]="selectedCategory" class="search-select">
+      <option value="">All Categories</option>
+      <option *ngFor="let cat of categories" [value]="cat">{{ cat }}</option>
+    </select>
+    <button (click)="searchBooks()" class="search-button">Search</button>
 
-    <select [(ngModel)]="sortBy" class="sort-select">
-      <option value="title">Tytuł</option>
-      <option value="author">Autor</option>
+    <select [(ngModel)]="sortOption" class="sort-select">
+      <option value="titleAsc">Title A–Z</option>
+      <option value="titleDesc">Title Z–A</option>
+      <option value="authorAsc">Author A–Z</option>
+      <option value="authorDesc">Author Z–A</option>
+      <option value="newest">Newest First</option>
+      <option value="oldest">Oldest First</option>
+      <option value="rating">Highest Rating</option>
+      <option value="reviews">Most Reviewed</option>
     </select>
   </div>
 


### PR DESCRIPTION
## Summary
- add API route for categories
- extend catalog search filters and sort options
- fetch categories in catalogue
- build complex search queries and new sort order

## Testing
- `npm test` *(fails: ng not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find Angular packages)*

------
https://chatgpt.com/codex/tasks/task_e_68495eb2e73c832894da83007b89fc2b