### PR TITLE
Enhance shelves and reviews layout

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -11,6 +11,7 @@ import { BestsellersComponent } from './pages/bestsellers/bestsellers.component'
 import { ContactComponent } from './pages/contact/contact.component';
 import { BookDetailComponent } from './pages/book-detail/book-detail.component';
 import { PasswordResetComponent } from './pages/password-reset/password-reset.component';
+import { ShelfComponent } from './pages/shelf/shelf.component';
 
 export const routes: Routes = [
   { path: '', component: HomeComponent },
@@ -24,4 +25,5 @@ export const routes: Routes = [
   { path: 'about-us', component: AboutUsComponent },
   { path: 'contact', component: ContactComponent },
   { path: 'password-reset', component: PasswordResetComponent },
+  { path: 'shelf/:id', component: ShelfComponent, canActivate: [AuthGuard] },
 ];

--- a/src/app/pages/book-detail/book-detail.component.css
+++ b/src/app/pages/book-detail/book-detail.component.css
@@ -1,5 +1,7 @@
 .book-detail-container {
     display: flex;
+    flex-direction: column;
+    align-items: center;
     justify-content: center;
     padding: 2rem;
     background: #121212;

--- a/src/app/pages/library/library.component.css
+++ b/src/app/pages/library/library.component.css
@@ -55,9 +55,9 @@
   color: #00b34d;
 }
 
-.shelf-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+.shelf-list {
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
 }
 
@@ -105,14 +105,26 @@
   background: #1e1e1e;
   padding: 1rem;
   border-radius: 8px;
+  width: 100%;
+}
+
+.shelf-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.shelf-link:hover {
+  text-decoration: underline;
 }
 
 
 .shelf-books {
   display: flex;
+  flex-wrap: nowrap;
   overflow-x: auto;
   gap: 1rem;
   padding-bottom: 0.5rem;
+  width: 100%;
 }
 
 .shelf-books app-book-card {

--- a/src/app/pages/library/library.component.html
+++ b/src/app/pages/library/library.component.html
@@ -24,11 +24,11 @@
       <h3>Your Shelves</h3>
       <a *ngIf="!showAllShelves" (click)="showAllShelves = true" class="see-all">See all shelves</a>
     </div>
-    <div class="shelf-grid">
+    <div class="shelf-list">
       <div class="shelf" *ngFor="let s of shelves | slice:0:(showAllShelves ? shelves.length : 6)">
-        <h4>{{ s.name }}</h4>
+        <h4><a [routerLink]="['/shelf', s.id]" class="shelf-link">{{ s.name }}</a></h4>
         <div class="shelf-books">
-          <app-book-card *ngFor="let sb of s.books | slice:0:3" [book]="sb"></app-book-card>
+          <app-book-card *ngFor="let sb of s.books" [book]="sb"></app-book-card>
         </div>
       </div>
     </div>

--- a/src/app/pages/shelf/shelf.component.css
+++ b/src/app/pages/shelf/shelf.component.css
@@ -1,0 +1,10 @@
+.shelf-page {
+  padding: 2rem;
+  color: #fff;
+}
+
+.shelf-books {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}

--- a/src/app/pages/shelf/shelf.component.html
+++ b/src/app/pages/shelf/shelf.component.html
@@ -1,0 +1,6 @@
+<div class="shelf-page" *ngIf="shelf">
+  <h2>{{ shelf.name }}</h2>
+  <div class="shelf-books">
+    <app-book-card *ngFor="let b of shelf.books" [book]="b"></app-book-card>
+  </div>
+</div>

--- a/src/app/pages/shelf/shelf.component.ts
+++ b/src/app/pages/shelf/shelf.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { ShelfService } from '../../services/shelf.service';
+import { BookCardComponent } from '../../shared/components/book-card/book-card.component';
+import { Shelf } from '../../shared/components/shelf';
+
+@Component({
+  standalone: true,
+  selector: 'app-shelf',
+  imports: [CommonModule, BookCardComponent],
+  templateUrl: './shelf.component.html',
+  styleUrls: ['./shelf.component.css']
+})
+export class ShelfComponent implements OnInit {
+  shelf: Shelf | null = null;
+
+  constructor(private route: ActivatedRoute, private shelfService: ShelfService) {}
+
+  ngOnInit(): void {
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+    this.shelfService.getShelf(id).subscribe(s => this.shelf = s);
+  }
+}

--- a/src/app/services/shelf.service.ts
+++ b/src/app/services/shelf.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 import { Shelf } from '../shared/components/shelf';
 
 @Injectable({ providedIn: 'root' })
@@ -27,5 +27,9 @@ export class ShelfService {
 
   getSharedShelf(token: string): Observable<Shelf> {
     return this.http.get<Shelf>(`http://localhost:3000/api/shared/${token}`);
+  }
+
+  getShelf(id: number): Observable<Shelf | null> {
+    return this.getShelves().pipe(map(arr => arr.find(s => s.id === id) || null));
   }
 }


### PR DESCRIPTION
## Summary
- stack book detail page sections vertically so reviews appear below
- display user shelves as full-width rows and link to new shelf pages
- support looking up shelves by id
- add dedicated shelf page

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684968022dcc8328b6e61e9f712176c4