### PR TITLE
Implement public profile page

### DIFF
--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -328,4 +328,35 @@ router.get('/shared/:token', async (req, res) => {
   }
 });
 
+// Public profile with public shelves only
+router.get('/:id/public', async (req, res) => {
+  const userId = parseInt(req.params.id, 10);
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        username: true,
+        shelves: {
+          where: { NOT: { shareToken: null } },
+          select: { id: true, name: true, shareToken: true }
+        }
+      }
+    });
+    if (!user) return res.status(404).json({ error: 'User not found' });
+    res.json({
+      id: user.id,
+      username: user.username,
+      shelves: user.shelves.map(s => ({
+        id: s.id,
+        name: s.name,
+        shareToken: s.shareToken
+      }))
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch public profile' });
+  }
+});
+
 module.exports = router;

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -12,6 +12,7 @@ import { ContactComponent } from './pages/contact/contact.component';
 import { BookDetailComponent } from './pages/book-detail/book-detail.component';
 import { PasswordResetComponent } from './pages/password-reset/password-reset.component';
 import { ShelfComponent } from './pages/shelf/shelf.component';
+import { PublicProfileComponent } from './pages/public-profile/public-profile.component';
 
 export const routes: Routes = [
   { path: '', component: HomeComponent },
@@ -26,4 +27,5 @@ export const routes: Routes = [
   { path: 'contact', component: ContactComponent },
   { path: 'password-reset', component: PasswordResetComponent },
   { path: 'shelf/:id', component: ShelfComponent, canActivate: [AuthGuard] },
+  { path: 'public-profile/:id', component: PublicProfileComponent },
 ];

--- a/src/app/pages/book-detail/book-detail.component.html
+++ b/src/app/pages/book-detail/book-detail.component.html
@@ -58,7 +58,9 @@
   <div class="reviews" *ngIf="reviews.length">
     <h3>Reviews</h3>
     <div class="review-item" *ngFor="let r of reviews">
-      <img class="review-avatar" [src]="'https://api.dicebear.com/6.x/initials/svg?seed=' + r.user.username" alt="avatar" />
+      <a [routerLink]="'/public-profile/' + r.user.id">
+        <img class="review-avatar" [src]="'https://api.dicebear.com/6.x/initials/svg?seed=' + r.user.username" alt="avatar" />
+      </a>
       <div class="review-content">
         <p class="review-meta"><strong>{{ r.user.username }}</strong> ({{ r.rating }}/5)</p>
         <p>{{ r.content }}</p>

--- a/src/app/pages/public-profile/public-profile.component.css
+++ b/src/app/pages/public-profile/public-profile.component.css
@@ -1,0 +1,14 @@
+.public-profile {
+  padding: 1rem;
+}
+.avatar {
+  width: 80px;
+  height: 80px;
+}
+.shelf-list {
+  list-style: none;
+  padding: 0;
+}
+.shelf-list li {
+  margin-bottom: 0.5rem;
+}

--- a/src/app/pages/public-profile/public-profile.component.html
+++ b/src/app/pages/public-profile/public-profile.component.html
@@ -1,0 +1,9 @@
+<div *ngIf="profile" class="public-profile">
+  <h2>{{ profile.username }}'s Public Shelves</h2>
+  <img class="avatar" [src]="'https://api.dicebear.com/6.x/initials/svg?seed=' + profile.username" alt="avatar" />
+  <ul class="shelf-list">
+    <li *ngFor="let s of profile.shelves">
+      <a [routerLink]="'/shared/' + s.shareToken">{{ s.name }}</a>
+    </li>
+  </ul>
+</div>

--- a/src/app/pages/public-profile/public-profile.component.ts
+++ b/src/app/pages/public-profile/public-profile.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { UserService } from '../../services/user.service';
+
+@Component({
+  selector: 'app-public-profile',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './public-profile.component.html',
+  styleUrls: ['./public-profile.component.css']
+})
+export class PublicProfileComponent implements OnInit {
+  profile: any = null;
+
+  constructor(private route: ActivatedRoute, private userService: UserService) {}
+
+  ngOnInit(): void {
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+    this.userService.getPublicProfile(id).subscribe(p => this.profile = p);
+  }
+}

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class UserService {
+  private api = 'http://localhost:3000/api/user';
+  constructor(private http: HttpClient) {}
+
+  getPublicProfile(id: number): Observable<any> {
+    return this.http.get<any>(`${this.api}/${id}/public`);
+  }
+}


### PR DESCRIPTION
## Summary
- add backend endpoint for viewing a user's public profile
- show a link on reviews to visit a user's public profile
- add route and component for the new public profile page
- create user service for retrieving public profile data

## Testing
- `npm test` *(fails: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68496f14e6448328bfdd6adcdb429ae7