### PR TITLE
Add shelf editing dialog

### DIFF
--- a/src/app/pages/library/library.component.css
+++ b/src/app/pages/library/library.component.css
@@ -117,6 +117,91 @@
   text-decoration: underline;
 }
 
+.shelf-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.shelf-actions a,
+.shelf-actions button {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.shelf-actions .open-btn {
+  background: #00cc5c;
+  color: #111;
+}
+
+.shelf-actions .edit-btn {
+  background: #444;
+  color: #fff;
+}
+
+.shelf-actions .share-btn {
+  background: transparent;
+  border: 2px solid #00cc5c;
+  color: #00cc5c;
+}
+
+.shelf-actions .share-link {
+  color: #00cc5c;
+  align-self: center;
+}
+
+.edit-dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.dialog-content {
+  background: #1e1e1e;
+  padding: 1rem 2rem;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.action-button {
+  padding: 8px 16px;
+  border: 2px solid #00cc5c;
+  background: transparent;
+  color: #00cc5c;
+  border-radius: 6px;
+  cursor: pointer;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.action-button.filled {
+  background: #00cc5c;
+  color: #121212;
+}
+
+.action-button.delete {
+  background: #b00020;
+  border-color: #b00020;
+  color: #fff;
+}
+
 
 .shelf-books {
   display: flex;

--- a/src/app/pages/library/library.component.html
+++ b/src/app/pages/library/library.component.html
@@ -27,9 +27,13 @@
     <div class="shelf-list">
       <div class="shelf" *ngFor="let s of shelves | slice:0:(showAllShelves ? shelves.length : 6)">
         <div class="shelf-title">
-          <h4><a [routerLink]="['/shelf', s.id]" class="shelf-link">{{ s.name }}</a></h4>
-          <button *ngIf="!s.isPublic" (click)="shareShelf(s)">Share</button>
-          <a *ngIf="s.isPublic" [href]="'/shared/' + s.shareToken" target="_blank">Share Link</a>
+          <h4>{{ s.name }}</h4>
+          <div class="shelf-actions">
+            <a class="open-btn" [routerLink]="['/shelf', s.id]">Open</a>
+            <button class="edit-btn" (click)="openEdit(s)">Edit</button>
+            <button *ngIf="!s.isPublic" class="share-btn" (click)="shareShelf(s)">Share</button>
+            <a *ngIf="s.isPublic" class="share-link" [href]="'/shared/' + s.shareToken" target="_blank">Share Link</a>
+          </div>
         </div>
         <div class="shelf-books">
           <app-book-card *ngFor="let sb of s.books" [book]="sb"></app-book-card>
@@ -41,6 +45,28 @@
   <div class="create-shelf">
     <input type="text" [(ngModel)]="newShelfName" placeholder="New shelf name" />
     <button (click)="createShelf()">Create Shelf</button>
+  </div>
+
+  <div class="edit-dialog" *ngIf="editingShelf">
+    <div class="dialog-content">
+      <h3>Edit Shelf</h3>
+      <label>
+        Name:
+        <input [(ngModel)]="editName" />
+      </label>
+      <label>
+        Visibility:
+        <select [(ngModel)]="editPublic">
+          <option [ngValue]="false">Private</option>
+          <option [ngValue]="true">Public</option>
+        </select>
+      </label>
+      <div class="dialog-actions">
+        <button class="action-button filled" (click)="saveEdit()">Save</button>
+        <button class="action-button delete" (click)="deleteShelf()">Delete</button>
+        <button class="action-button" (click)="cancelEdit()">Cancel</button>
+      </div>
+    </div>
   </div>
 
 </div>

--- a/src/app/pages/library/library.component.ts
+++ b/src/app/pages/library/library.component.ts
@@ -28,6 +28,9 @@ export class LibraryComponent implements OnInit {
   shelves: Shelf[] = [];
   newShelfName = '';
   showAllShelves = false;
+  editingShelf: Shelf | null = null;
+  editName = '';
+  editPublic = false;
 
   constructor(
     private auth: AuthService,
@@ -99,6 +102,39 @@ export class LibraryComponent implements OnInit {
       },
       error: err => console.error('Failed to share shelf', err)
     });
+  }
+
+  openEdit(shelf: Shelf): void {
+    this.editingShelf = shelf;
+    this.editName = shelf.name;
+    this.editPublic = !!shelf.isPublic;
+  }
+
+  saveEdit(): void {
+    if (!this.editingShelf) return;
+    this.shelvesService.updateShelf(this.editingShelf.id, { name: this.editName, isPublic: this.editPublic }).subscribe({
+      next: updated => {
+        Object.assign(this.editingShelf, updated);
+        this.editingShelf = null;
+      },
+      error: err => console.error('Failed to update shelf', err)
+    });
+  }
+
+  deleteShelf(): void {
+    if (!this.editingShelf) return;
+    const id = this.editingShelf.id;
+    this.shelvesService.deleteShelf(id).subscribe({
+      next: () => {
+        this.shelves = this.shelves.filter(s => s.id !== id);
+        this.editingShelf = null;
+      },
+      error: err => console.error('Failed to delete shelf', err)
+    });
+  }
+
+  cancelEdit(): void {
+    this.editingShelf = null;
   }
 
 }

--- a/src/app/services/shelf.service.ts
+++ b/src/app/services/shelf.service.ts
@@ -25,6 +25,14 @@ export class ShelfService {
     return this.http.post<{ shareToken: string }>(`${this.api}/${shelfId}/share`, {});
   }
 
+  updateShelf(id: number, data: { name?: string; isPublic?: boolean }): Observable<Shelf> {
+    return this.http.put<Shelf>(`${this.api}/${id}`, data);
+  }
+
+  deleteShelf(id: number): Observable<any> {
+    return this.http.delete(`${this.api}/${id}`);
+  }
+
   getSharedShelf(token: string): Observable<Shelf> {
     return this.http.get<Shelf>(`http://localhost:3000/api/shared/${token}`);
   }


### PR DESCRIPTION
## Summary
- make library shelves editable via dialog
- add API endpoints to update or delete shelves

## Testing
- `npm test --silent --no-progress --unsafe-perm` *(fails: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_684971ed87e48328900bac7561fff885