### PR TITLE
Add shelf deletion and all books feature

### DIFF
--- a/src/app/pages/library/library.component.css
+++ b/src/app/pages/library/library.component.css
@@ -216,3 +216,19 @@
   flex: 0 0 auto;
 }
 
+.all-books-section .all-book {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.all-books-section button {
+  margin-top: 0.5rem;
+  padding: 6px 12px;
+  border: none;
+  background: #b00020;
+  color: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+}
+

--- a/src/app/pages/library/library.component.html
+++ b/src/app/pages/library/library.component.html
@@ -19,6 +19,7 @@
     </div>
   </section>
 
+
   <section *ngIf="shelves.length" class="shelf-preview">
     <div class="shelf-header">
       <h3>Your Shelves</h3>
@@ -38,6 +39,16 @@
         <div class="shelf-books">
           <app-book-card *ngFor="let sb of s.books" [book]="sb"></app-book-card>
         </div>
+      </div>
+    </div>
+  </section>
+
+  <section *ngIf="allBooks.length" class="all-books-section">
+    <h3>All Books</h3>
+    <div class="books-grid">
+      <div class="all-book" *ngFor="let b of allBooks">
+        <app-book-card [book]="b"></app-book-card>
+        <button (click)="deleteFromAll(b.id)">Remove</button>
       </div>
     </div>
   </section>

--- a/src/app/pages/shelf/shelf.component.css
+++ b/src/app/pages/shelf/shelf.component.css
@@ -8,3 +8,15 @@
   flex-wrap: wrap;
   gap: 1rem;
 }
+
+.book-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.select-actions {
+  margin: 1rem 0;
+  display: flex;
+  gap: 0.5rem;
+}

--- a/src/app/pages/shelf/shelf.component.html
+++ b/src/app/pages/shelf/shelf.component.html
@@ -2,7 +2,15 @@
   <h2>{{ shelf.name }}</h2>
   <button *ngIf="!shelf.isPublic" (click)="shareShelf()">Share Shelf</button>
   <a *ngIf="shelf.isPublic" [href]="'/shared/' + shelf.shareToken" target="_blank">Share Link</a>
+  <button *ngIf="!selectMode" (click)="toggleSelectMode()">Select Books</button>
+  <div *ngIf="selectMode" class="select-actions">
+    <button (click)="deleteSelected()">Delete Selected</button>
+    <button (click)="toggleSelectMode()">Cancel</button>
+  </div>
   <div class="shelf-books">
-    <app-book-card *ngFor="let b of shelf.books" [book]="b"></app-book-card>
+    <div class="book-wrapper" *ngFor="let b of shelf.books">
+      <input *ngIf="selectMode" type="checkbox" (change)="toggleBook(b.id, $event.target.checked)">
+      <app-book-card [book]="b"></app-book-card>
+    </div>
   </div>
 </div>

--- a/src/app/services/shelf.service.ts
+++ b/src/app/services/shelf.service.ts
@@ -33,6 +33,14 @@ export class ShelfService {
     return this.http.delete(`${this.api}/${id}`);
   }
 
+  removeBookFromShelf(shelfId: number, bookId: string): Observable<any> {
+    return this.http.delete(`${this.api}/${shelfId}/books/${bookId}`);
+  }
+
+  removeBookFromAllShelves(bookId: string): Observable<any> {
+    return this.http.delete(`${this.api}/books/${bookId}`);
+  }
+
   getSharedShelf(token: string): Observable<Shelf> {
     return this.http.get<Shelf>(`http://localhost:3000/api/shared/${token}`);
   }


### PR DESCRIPTION
## Summary
- allow removing books from shelves via new endpoints
- support deleting a book from all shelves
- add select mode in shelf page to delete multiple books
- show unique "All Books" list in library with delete option

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684975814ea48328ae26d5f1c525828f