### PR TITLE
Add profile preferences and account removal

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -35,7 +35,7 @@ router.post('/login', async (req, res) => {
   const isValid = await bcrypt.compare(password, user.passwordHash);
   if (!isValid) return res.status(401).json({ error: 'Invalid credentials' });
 
-  const token = jwt.sign({ id: user.id, username: user.username }, process.env.JWT_SECRET, { expiresIn: '2h' });
+  const token = jwt.sign({ id: user.id, username: user.username }, process.env.JWT_SECRET, { expiresIn: '30d' });
 
   res.json({ token, user: { id: user.id, username: user.username, email: user.email } });
 });

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -253,6 +253,23 @@ router.put('/me', authenticateToken, async (req, res) => {
   }
 });
 
+// Delete account and all user data
+router.delete('/me', authenticateToken, async (req, res) => {
+  const userId = req.user.id;
+  try {
+    await prisma.shelfBook.deleteMany({ where: { shelf: { userId } } });
+    await prisma.shelf.deleteMany({ where: { userId } });
+    await prisma.userBook.deleteMany({ where: { userId } });
+    await prisma.review.deleteMany({ where: { userId } });
+    await prisma.passwordResetToken.deleteMany({ where: { userId } });
+    await prisma.user.delete({ where: { id: userId } });
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to delete account' });
+  }
+});
+
 // Get shelves with books
 router.get('/user/shelves', authenticateToken, async (req, res) => {
   const userId = req.user.id;

--- a/src/app/pages/profile/profile.component.css
+++ b/src/app/pages/profile/profile.component.css
@@ -1,6 +1,77 @@
-.profile-page {
-  padding: 2rem;
+.profile-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: linear-gradient(to right, #00cc5c, #00b34d);
   color: #fff;
 }
 
+.profile-box {
+  background-color: #111;
+  padding: 40px;
+  border-radius: 12px;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+  width: 100%;
+  max-width: 500px;
+}
 
+.profile-box h2 {
+  text-align: center;
+  margin-bottom: 25px;
+  font-weight: 600;
+}
+
+.input-group {
+  margin-bottom: 20px;
+}
+
+.input-group label {
+  display: block;
+  margin-bottom: 6px;
+  font-weight: 500;
+}
+
+.input-group input {
+  width: 100%;
+  padding: 10px;
+  border-radius: 6px;
+  border: none;
+  background-color: #222;
+  color: #eee;
+  font-size: 14px;
+}
+
+.input-group input:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #00cc5c;
+}
+
+.action-button,
+.delete-button {
+  width: 100%;
+  padding: 12px;
+  border: none;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 10px;
+}
+
+.action-button {
+  background-color: #00cc5c;
+  color: #111;
+}
+
+.action-button:hover {
+  background-color: #00b34d;
+}
+
+.delete-button {
+  background-color: #d9534f;
+  color: #fff;
+}
+
+.delete-button:hover {
+  background-color: #c9302c;
+}

--- a/src/app/pages/profile/profile.component.html
+++ b/src/app/pages/profile/profile.component.html
@@ -1,11 +1,19 @@
-<div class="profile-page" *ngIf="username">
-  <h2>{{ username }}'s Profile</h2>
-  <div>
-    <label>New Username: <input [(ngModel)]="newUsername" /></label>
+<div class="profile-container" *ngIf="username">
+  <div class="profile-box animate">
+    <h2>Welcome, {{ username }}</h2>
+    <div class="input-group">
+      <label>New Username</label>
+      <input [(ngModel)]="newUsername" />
+    </div>
+    <div class="input-group">
+      <label>Favourite categories (comma separated)</label>
+      <input [(ngModel)]="categories" />
+    </div>
+    <div class="input-group">
+      <label>Favourite book</label>
+      <input [(ngModel)]="favouriteBook" />
+    </div>
+    <button class="action-button" (click)="save()">Save</button>
+    <button class="delete-button" (click)="deleteAccount()">Delete Account</button>
   </div>
-  <div>
-    <label>Preferences JSON:</label>
-    <textarea [(ngModel)]="preferencesText"></textarea>
-  </div>
-  <button (click)="save()">Save</button>
 </div>

--- a/src/app/pages/profile/profile.component.ts
+++ b/src/app/pages/profile/profile.component.ts
@@ -14,7 +14,8 @@ import { AuthService } from '../../services/auth.service';
 export class ProfileComponent implements OnInit {
   username: string | null = null;
   newUsername = '';
-  preferencesText = '';
+  categories = '';
+  favouriteBook = '';
 
   constructor(private auth: AuthService, private router: Router, private http: HttpClient) {}
 
@@ -24,12 +25,19 @@ export class ProfileComponent implements OnInit {
       return;
     }
     this.username = this.auth.getUsername();
+    this.http.get<any>('http://localhost:3000/api/me').subscribe(user => {
+      this.categories = (user.preferences?.categories || []).join(', ');
+      this.favouriteBook = user.preferences?.favouriteBook || '';
+    });
   }
 
   save(): void {
     const payload: any = {};
     if (this.newUsername) payload.username = this.newUsername;
-    try { payload.preferences = JSON.parse(this.preferencesText || '{}'); } catch { payload.preferences = {}; }
+    payload.preferences = {
+      categories: this.categories.split(',').map((c: string) => c.trim()).filter((c: string) => c),
+      favouriteBook: this.favouriteBook
+    };
     this.http.put<any>('http://localhost:3000/api/me', payload).subscribe({
       next: user => {
         this.username = user.username;
@@ -38,6 +46,17 @@ export class ProfileComponent implements OnInit {
         alert('Profile updated');
       },
       error: err => alert('Failed to update profile')
+    });
+  }
+
+  deleteAccount(): void {
+    if (!confirm('Are you sure you want to delete your account?')) return;
+    this.auth.deleteAccount().subscribe({
+      next: () => {
+        this.auth.logout();
+        this.router.navigate(['/']);
+      },
+      error: () => alert('Failed to delete account')
     });
   }
 

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -50,12 +50,16 @@ export class AuthService {
   verifySession(): void {
     const token = this.getToken();
     if (!token) return;
-    this.http.get<{ username: string }>('http://localhost:3000/api/user/me').subscribe({
+    this.http.get<{ username: string }>('http://localhost:3000/api/me').subscribe({
       next: user => {
         this.userSubject.next(user.username);
       },
       error: () => this.logout()
     });
+  }
+
+  deleteAccount() {
+    return this.http.delete('http://localhost:3000/api/me');
   }
 
   getToken(): string | null {


### PR DESCRIPTION
## Summary
- extend JWT expiry for longer sessions
- add account deletion endpoint
- improve session verification
- enhance profile page to store categories and favourite book with new styles

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497d72dc5483288fdf4406db67b73a