### PR TITLE
Style updates and profile preferences

### DIFF
--- a/src/app/pages/library/library.component.css
+++ b/src/app/pages/library/library.component.css
@@ -14,16 +14,24 @@
 .controls select {
   padding: 10px 14px;
   border-radius: 8px;
-  border: none;
+  border: 1px solid #00cc5c;
   background: #222;
   color: #fff;
   transition: box-shadow 0.3s;
+  appearance: none;
 }
 
 .controls input:focus,
 .controls select:focus {
   outline: none;
   box-shadow: 0 0 0 2px #00cc5c;
+}
+
+.controls select {
+  background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg xmlns%3D%22http://www.w3.org/2000/svg%22 viewBox%3D%220 0 4 5%22%3E%3Cpath fill%3D%22%23ffffff%22 d%3D%22M2 0L0 2h4L2 0zM0 3l2 2 2-2H0z%22/%3E%3C/svg%3E');
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 30px;
 }
 
 
@@ -213,7 +221,7 @@
 }
 
 .shelf-books app-book-card {
-  flex: 0 0 auto;
+  flex: 0 0 150px;
 }
 
 .all-books-section .all-book {

--- a/src/app/pages/profile/profile.component.css
+++ b/src/app/pages/profile/profile.component.css
@@ -3,7 +3,7 @@
   align-items: center;
   justify-content: center;
   min-height: 100vh;
-  background: linear-gradient(to right, #00cc5c, #00b34d);
+  background: linear-gradient(to right, #4b0082, #8a2be2);
   color: #fff;
 }
 
@@ -74,4 +74,17 @@
 
 .delete-button:hover {
   background-color: #c9302c;
+}
+
+.pref-list {
+  margin: 1rem 0;
+  padding: 0;
+  list-style: none;
+  color: #eee;
+}
+.pref-list li {
+  background: #222;
+  padding: 8px 12px;
+  border-radius: 6px;
+  margin-bottom: 6px;
 }

--- a/src/app/pages/profile/profile.component.html
+++ b/src/app/pages/profile/profile.component.html
@@ -13,6 +13,13 @@
       <label>Favourite book</label>
       <input [(ngModel)]="favouriteBook" />
     </div>
+    <button class="action-button" (click)="addPreferences()">Add Preferences</button>
+    <ul class="pref-list" *ngIf="addedPreferences.length">
+      <li *ngFor="let p of addedPreferences">
+        <strong>Categories:</strong> {{ p.categories.join(', ') }} -
+        <strong>Favourite Book:</strong> {{ p.favouriteBook }}
+      </li>
+    </ul>
     <button class="action-button" (click)="save()">Save</button>
     <button class="delete-button" (click)="deleteAccount()">Delete Account</button>
   </div>

--- a/src/app/pages/profile/profile.component.ts
+++ b/src/app/pages/profile/profile.component.ts
@@ -18,6 +18,7 @@ export class ProfileComponent implements OnInit {
   newUsername = '';
   categories = '';
   favouriteBook = '';
+  addedPreferences: {categories: string[]; favouriteBook: string}[] = [];
 
   constructor(private auth: AuthService, private router: Router, private http: HttpClient) {}
 
@@ -31,6 +32,19 @@ export class ProfileComponent implements OnInit {
       this.categories = (user.preferences?.categories || []).join(', ');
       this.favouriteBook = user.preferences?.favouriteBook || '';
     });
+  }
+
+  addPreferences(): void {
+    const cats = this.categories
+      .split(',')
+      .map(c => c.trim())
+      .filter(c => c);
+    this.addedPreferences.push({
+      categories: cats,
+      favouriteBook: this.favouriteBook
+    });
+    this.categories = '';
+    this.favouriteBook = '';
   }
 
   save(): void {

--- a/src/app/pages/public-profile/public-profile.component.css
+++ b/src/app/pages/public-profile/public-profile.component.css
@@ -35,5 +35,5 @@
 }
 
 .shelf-books app-book-card {
-  flex: 0 0 auto;
+  flex: 0 0 150px;
 }

--- a/src/app/pages/shelf/shelf.component.css
+++ b/src/app/pages/shelf/shelf.component.css
@@ -15,8 +15,31 @@
   gap: 0.5rem;
 }
 
+.book-wrapper app-book-card {
+  flex: 0 0 150px;
+}
+
 .select-actions {
   margin: 1rem 0;
   display: flex;
   gap: 0.5rem;
+}
+
+.shelf-page button {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 6px;
+  background: #00cc5c;
+  color: #111;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.shelf-page button:hover {
+  background: #00b34d;
+}
+
+.select-actions button:first-child {
+  background: #b00020;
+  color: #fff;
 }


### PR DESCRIPTION
## Summary
- style the `<select>` control with custom border and arrow icon
- fix shelf book card sizes for consistent width
- revamp private profile page colors and allow adding preferences
- add styles for shelf action buttons

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498da583548328a9de273e8e1aee51