### PR TITLE
Add unit tests for service classes

### DIFF
--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AuthService]
+    });
+    service = TestBed.inject(AuthService);
+    http = TestBed.inject(HttpTestingController);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    http.verify();
+    localStorage.clear();
+  });
+
+  it('should login and store token and username', () => {
+    service.login('a@b.com', 'pass').subscribe();
+    const req = http.expectOne('http://localhost:3000/api/auth/login');
+    expect(req.request.method).toBe('POST');
+    req.flush({ token: 'tok', user: { username: 'John', email: 'a@b.com', id: 1 } });
+
+    expect(localStorage.getItem('token')).toBe('tok');
+    expect(localStorage.getItem('username')).toBe('John');
+    expect(service.isLoggedIn()).toBeTrue();
+  });
+
+  it('should logout and clear storage', () => {
+    localStorage.setItem('token', 'abc');
+    localStorage.setItem('username', 'John');
+    service.logout();
+    expect(localStorage.getItem('token')).toBeNull();
+    expect(localStorage.getItem('username')).toBeNull();
+    service.user$.subscribe(value => expect(value).toBeNull());
+  });
+
+  it('should verify session and update username', () => {
+    localStorage.setItem('token', 'tok');
+    service.verifySession();
+    const req = http.expectOne('http://localhost:3000/api/me');
+    expect(req.request.method).toBe('GET');
+    req.flush({ username: 'Jane' });
+    expect(localStorage.getItem('username')).toBe('Jane');
+  });
+});

--- a/src/app/services/library.service.spec.ts
+++ b/src/app/services/library.service.spec.ts
@@ -1,0 +1,42 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { LibraryService } from './library.service';
+
+describe('LibraryService', () => {
+  let service: LibraryService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [LibraryService]
+    });
+    service = TestBed.inject(LibraryService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+  });
+
+  it('should fetch user books', () => {
+    const mock = [{ id: '1', volumeInfo: { title: 'Test' } }];
+    service.getMyBooks().subscribe(data => {
+      expect(data).toEqual(mock);
+    });
+    const req = http.expectOne('http://localhost:3000/api/user/books');
+    expect(req.request.method).toBe('GET');
+    req.flush(mock);
+  });
+
+  it('should add a book', () => {
+    const payload = { id: '1' };
+    service.addBook(payload).subscribe(res => {
+      expect(res).toEqual({ success: true });
+    });
+    const req = http.expectOne('http://localhost:3000/api/user/books');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(payload);
+    req.flush({ success: true });
+  });
+});

--- a/src/app/services/shelf.service.spec.ts
+++ b/src/app/services/shelf.service.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ShelfService } from './shelf.service';
+
+describe('ShelfService', () => {
+  let service: ShelfService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ShelfService]
+    });
+    service = TestBed.inject(ShelfService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+  });
+
+  it('should create a shelf', () => {
+    service.createShelf('New Shelf').subscribe((res: any) => {
+      expect(res).toEqual({ id: 1, name: 'New Shelf', books: [] });
+    });
+    const req = http.expectOne('http://localhost:3000/api/user/shelves');
+    expect(req.request.method).toBe('POST');
+    req.flush({ id: 1, name: 'New Shelf', books: [] });
+  });
+
+  it('should delete a shelf', () => {
+    service.deleteShelf(1).subscribe(res => {
+      expect(res).toEqual({ success: true });
+    });
+    const req = http.expectOne('http://localhost:3000/api/user/shelves/1');
+    expect(req.request.method).toBe('DELETE');
+    req.flush({ success: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jasmine/Karma unit tests for AuthService
- add tests for LibraryService and ShelfService

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849a74e42948328a4cee8a8100abf6b